### PR TITLE
Encoding issue on creation lines for htaccess file

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -55,8 +55,8 @@ function hasMarkers( $marker, $file = null ) {
 	$content = $fs->get_contents( $file );
 
 	return $content &&
-	       false !== strpos( $content, getOpeningMarker( $marker ) ) &&
-	       false !== strpos( $content, getClosingMarker( $marker ) );
+			false !== strpos( $content, getOpeningMarker( $marker ) ) &&
+			false !== strpos( $content, getClosingMarker( $marker ) );
 }
 
 /**
@@ -65,7 +65,7 @@ function hasMarkers( $marker, $file = null ) {
  * Note: Be sure to check if hasMarkers() returns true first!
  *
  * @param string      $marker   The marker name.
- * @param string      $location The location to insert markers (e.g. before or after)
+ * @param string      $location The location to insert markers (e.g. before or after).
  * @param string|null $file     The path to the file.
  *
  * @return bool
@@ -89,10 +89,10 @@ function addMarkers( $marker, $location = 'before', $file = null ) {
 				array_merge(
 					$lines['beforeMarkers'],
 					$lines['afterMarkers'],
-					[
+					array(
 						getOpeningMarker( $marker ),
-						getClosingMarker( $marker )
-					]
+						getClosingMarker( $marker ),
+					)
 				)
 			);
 			break;
@@ -100,10 +100,10 @@ function addMarkers( $marker, $location = 'before', $file = null ) {
 			$content = implode(
 				PHP_EOL,
 				array_merge(
-					[
+					array(
 						getOpeningMarker( $marker ),
-						getClosingMarker( $marker )
-					],
+						getClosingMarker( $marker ),
+					),
 					$lines['beforeMarkers'],
 					$lines['afterMarkers']
 				)
@@ -193,9 +193,9 @@ function insertContent( $marker, $content, $file = null ) {
 		PHP_EOL,
 		array_merge(
 			$lines['beforeMarkers'],
-			[ getOpeningMarker( $marker ) ],
+			array( getOpeningMarker( $marker ) ),
 			$lines['betweenMarkers'],
-			[ getClosingMarker( $marker ) ],
+			array( getClosingMarker( $marker ) ),
 			$lines['afterMarkers']
 		)
 	);
@@ -204,9 +204,11 @@ function insertContent( $marker, $content, $file = null ) {
 }
 
 /**
+ * Add content to htaccess file.
+ * 
  * @param string       $marker   The marker name.
  * @param string|array $content  The content of the file as a string or array of lines.
- * @param string       $location The location to insert markers (e.g. before or after)
+ * @param string       $location The location to insert markers (e.g. before or after).
  * @param string       $file     The file path.
  *
  * @return bool
@@ -238,9 +240,9 @@ function getLinesRelativeToMarkers( array $lines, $marker ) {
 	$foundOpeningMarker = false;
 	$foundClosingMarker = false;
 
-	$beforeMarkers  = [];
-	$betweenMarkers = [];
-	$afterMarkers   = [];
+	$beforeMarkers  = array();
+	$betweenMarkers = array();
+	$afterMarkers   = array();
 
 	foreach ( $lines as $line ) {
 		if ( ! $foundOpeningMarker && false !== strpos( $line, $openingMarker ) ) {
@@ -259,32 +261,36 @@ function getLinesRelativeToMarkers( array $lines, $marker ) {
 		}
 	}
 
-	return [
+	return array(
 		'beforeMarkers'  => $beforeMarkers,
 		'betweenMarkers' => $betweenMarkers,
 		'afterMarkers'   => $afterMarkers,
-	];
+	);
 }
 
 /**
  * Convert the contents of a file to an array of lines.
  *
- * @param string $content File content
+ * @param string $content File content.
  *
  * @return array
  */
 function convertContentToLines( $content ) {
-	$lines = [];
+	$lines = array();
 
 	if ( is_array( $content ) ) {
 		return $content;
 	}
 
 	if ( is_string( $content ) ) {
-		$lines = preg_split( '/\R/', $content );
+		if ( ! mb_check_encoding( $content, 'UTF-8' ) ) {
+			$content = mb_convert_encoding( $content, 'UTF-8', 'auto' );
+		}
+		$lines = preg_split( '/\r\n|\r|\n/', $content );
+		$lines = array_filter( $lines, fn( $line ) => trim( $line ) !== '' );
 	}
 
-	return is_array( $lines ) ? (array) $lines : [];
+	return is_array( $lines ) ? (array) $lines : array();
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

Scenario: use a not latin language (in example Chinese), then save permalinks. Default rules set by WordPress in the .htaccess file are wrong and cause 500 error.

The pull request wants fix this issue adding a needed encoding when the htaccess file is written again adding new rules.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

<!-- - [] I have read the [CONTRIBUTING](https://github.com/wp-forge/.github/blob/master/.github/CONTRIBUTING.md) doc -->
- [x] Linting and tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
