### PR TITLE
use older function

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -287,7 +287,7 @@ function convertContentToLines( $content ) {
 			$content = mb_convert_encoding( $content, 'UTF-8', 'auto' );
 		}
 		$lines = preg_split( '/\r\n|\r|\n/', $content );
-		$lines = array_filter( $lines, fn( $line ) => trim( $line ) !== '' );
+		$lines = array_filter( $lines, fn( $line ) { return trim( $line ) !== '' } );
 	}
 
 	return is_array( $lines ) ? (array) $lines : array();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -287,7 +287,7 @@ function convertContentToLines( $content ) {
 			$content = mb_convert_encoding( $content, 'UTF-8', 'auto' );
 		}
 		$lines = preg_split( '/\r\n|\r|\n/', $content );
-		$lines = array_filter( $lines, fn( $line ) { return trim( $line ) !== '' } );
+		$lines = array_filter( $lines, function( $line ) { return trim( $line ) !== ''; } );
 	}
 
 	return is_array( $lines ) ? (array) $lines : array();


### PR DESCRIPTION
## Proposed changes

This reverts to using older function syntax. The arrow function was introduced in PHP 7.4, and we're using this dependency in a project that still supports PHP 7.3.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

<!-- - [] I have read the [CONTRIBUTING](https://github.com/wp-forge/.github/blob/master/.github/CONTRIBUTING.md) doc -->
- [] Linting and tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
